### PR TITLE
Handle .jpeg files by default & support responsive-loader

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -3,7 +3,7 @@ const DEFAULT_OPTIONS = {
   noWebpClass: 'no-webp',
   webpClass: 'webp',
   rename: oldName => {
-    return oldName.replace(/\.(jpg|png)/gi, '.webp')
+    return oldName.replace(/\.(jpe?g|png)/gi, '.webp')
   }
 }
 
@@ -28,7 +28,7 @@ module.exports = (opts = {}) => {
   return {
     postcssPlugin: 'webp-in-css/plugin',
     Declaration (decl) {
-      if (/\.(jpg|png)(?!\.webp)/i.test(decl.value)) {
+      if (/\.(jpe?g|png)(?!(\.webp|.*[&?]format=webp))/i.test(decl.value)) {
         let rule = decl.parent
         if (rule.selector.includes(`.${noWebpClass}`)) return
         let webp = rule.cloneAfter()

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -17,6 +17,24 @@ it('adds classes and WebP link', () => {
   )
 })
 
+it('should work with jpeg', () => {
+  run(
+    '@media screen { a, b { color: black; background: url(./image.jpeg) } }',
+    '@media screen { ' +
+      'a, b { color: black } ' +
+      'body.no-webp a, body.no-webp b { background: url(./image.jpeg) } ' +
+      'body.webp a, body.webp b { background: url(./image.webp) } ' +
+      '}'
+  )
+})
+
+it('should skip urls with [&?]format=webp', () => {
+  run(
+    '@media screen { a, b { color: black; background: url(./image.jpeg?format=webp) } }',
+    '@media screen { a, b { color: black; background: url(./image.jpeg?format=webp) } }'
+  )
+})
+
 it('removes empty rule', () => {
   run(
     'a,b { background: url(./image.PNG) }',


### PR DESCRIPTION
I added handling jpeg to default rename function, this should not break anything.

Also this PR makes webp-in-css/plugin skip urls with [?&]format=webp, which is very usefull with https://github.com/dazuaz/responsive-loader This makes it really easy to convert images to webp in webpack.

```js
// postcss.config.js

'webp-in-css/plugin': {
  rename: oldName => {
    return oldName.replace(/\.(jpe?g|png)/gi, '.$1?format=webp')
  }
}
````

```js
// webpack.config.js
{
  test: /\.(jpe?g|png|webp)$/i,
  use: [
    {
      loader: 'responsive-loader',
      options: {
        adapter: require('responsive-loader/sharp')
      }
    },
    {
      loader: 'url-loader',
      options: {
        limit: 10000,
        name: 'static/media/[name].[hash:8].[ext]',
      }
    }
  ]
}
```