### PR TITLE
Fix processBackgroundValue return value

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -28,11 +28,16 @@ module.exports = (opts = {}) => {
   function processBackgroundValue(value) {
     // check for image-set
     // https://developer.mozilla.org/en-US/docs/Web/CSS/image/image-set
-    if (value.includes('image-set')) {
-      return /(image-set.*\))/gm.exec(value)[0] ?? value
-    } else {
-      return /(url.*\))/gm.exec(value)[0] ?? value
+    let clearValue = 
+      value.includes('image-set') ? 
+      /(image-set.*\))/gm.exec(value) :
+      /(url.*\))/gm.exec(value)
+
+    if (!clearValue) {
+      return value;
     }
+
+    return clearValue[0] ?? value;
   }
   
   /**


### PR DESCRIPTION
Good day!
I found an error in the case where css has multiple background values like this:

`
background: url('../img/bg-frame.png') no-repeat;
background: none;
`

The plugin crashed with an error "Cannot read properties of null (reading '0')" when the regular expression did not find matches in the function processBackgroundValue.